### PR TITLE
Change on AWS agent configuration to match logback

### DIFF
--- a/spring-boot-projects/aws-java-logging/resources/amazon-cloudwatch-agent.json
+++ b/spring-boot-projects/aws-java-logging/resources/amazon-cloudwatch-agent.json
@@ -4,7 +4,7 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/home/ec2-user/blog-aws-java-logging/logs/aws-java-logging.log",
+            "file_path": "/home/ec2-user/blog-aws-java-logging/logs/blog-aws-java-logging.log",
             "log_group_name": "blog-aws-java-logging",
             "log_stream_name": "blog-aws-java-logging-{instance_id}.log",
             "timestamp_format": "%Y-%m-%d %H:%M:%S.%f",


### PR DESCRIPTION
If the configuration here doesn't match the configuration over https://github.com/isaaceindhoven/isaac-developer-blog-paulm/blob/master/spring-boot-projects/aws-java-logging/src/main/resources/logback-spring.xml, the agent won't be able to find the log file